### PR TITLE
Refactor documents + types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
             -   name: PHPStan
                 run: "./vendor/bin/phpstan analyze -c vendor-bin/test/vendor/21torr/php-cs/phpstan/lib.neon . --ansi --error-format=checkstyle | cs2pr"
 
-            #-   name: PHPUnit
-            #    # --teamcity output used by `mheap/phpunit-matcher-action`
-            #    run: "./vendor/bin/simple-phpunit --teamcity"
+            -   name: PHPUnit
+                # --teamcity output used by `mheap/phpunit-matcher-action`
+                run: "./vendor/bin/simple-phpunit --teamcity"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
                 run: composer install --optimize-autoloader --classmap-authoritative --no-interaction
 
             -   name: Composer Normalize
-                run: composer normalize --indent-style tab --indent-size 1 --dry-run --ansi
+                run: composer-normalize --indent-style tab --indent-size 1 --dry-run --ansi
 
             -   name: PHP CS Fixer
                 run: "./vendor/bin/php-cs-fixer fix --diff --config vendor-bin/test/vendor/21torr/php-cs/.php-cs-fixer.dist.php --dry-run --no-interaction --ansi --format=checkstyle | cs2pr"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",
-		"roave/security-advisories": "dev-latest"
+		"roave/security-advisories": "dev-latest",
+		"symfony/phpunit-bridge": "^5.3"
 	},
 	"config": {
 		"sort-packages": true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.4/phpunit.xsd"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="9.4" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Bundle tests">
+            <directory>tests</directory>
+            <exclude>tests/fixtures</exclude>
+        </testsuite>
+    </testsuites>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>

--- a/src/Data/DataStructureValidationTrait.php
+++ b/src/Data/DataStructureValidationTrait.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Torr\PrismicApi\Data;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+use Torr\PrismicApi\Exception\Data\InvalidDataStructureException;
+
+trait DataStructureValidationTrait
+{
+	/**
+	 * Validates the given data according to the constraints.
+	 *
+	 * @param string|null $validationMessage A message that is added to the exception in case the validation fails.
+	 */
+	private function validateDataStructure (array $data, ?Constraint $constraint, ?string $validationMessage = null) : void
+	{
+		// always valid if no constraints given
+		if (null === $constraint)
+		{
+			return;
+		}
+
+		$validator = Validation::createValidator();
+		$violations = $validator->validate($data, $constraint);
+
+		if (\count($violations) > 0)
+		{
+			throw new InvalidDataStructureException(
+				static::class,
+				$violations,
+				$validationMessage,
+			);
+		}
+	}
+}

--- a/src/Data/Dataset.php
+++ b/src/Data/Dataset.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Torr\PrismicApi\Data;
+
+use Symfony\Component\Validator\Constraint;
+use Torr\PrismicApi\Data\Document\Document;
+
+/**
+ * A generic dataset container.
+ *
+ * Is used as basis for every item that comes from Prismic.
+ * Documents should extend from {@see Document}, slices should extend {@see Slice}.
+ * This class is mainly useful if you want to extract nested data into a separate class for easier usage.
+ */
+abstract class Dataset
+{
+	use DataStructureValidationTrait;
+	protected array $data;
+
+	/**
+	 */
+	public function __construct (array $data)
+	{
+		$this->validateDataStructure($data, $this->getValidationConstraints());
+		$this->data = $data;
+	}
+
+
+	/**
+	 * Returns the validation constraints for this dataset
+	 */
+	abstract protected function getValidationConstraints () : ?Constraint;
+}

--- a/src/Data/Document/Document.php
+++ b/src/Data/Document/Document.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Torr\PrismicApi\Data\Document;
+
+use Torr\PrismicApi\Data\Dataset;
+use Torr\PrismicApi\Exception\Data\InvalidDataStructureException;
+
+/**
+ * A top level
+ */
+abstract class Document extends Dataset
+{
+	protected DocumentAttributes $attributes;
+
+	/**
+	 */
+	public function __construct (array $data)
+	{
+		$itemData = $data["data"] ?? null;
+
+		if (!\is_array($itemData))
+		{
+			throw new InvalidDataStructureException(static::class, null, "No nested data key.");
+		}
+
+		parent::__construct($itemData);
+		$this->attributes = new DocumentAttributes($data);
+	}
+
+	/**
+	 */
+	public function getAttributes () : DocumentAttributes
+	{
+		return $this->attributes;
+	}
+}

--- a/src/Data/Document/Document.php
+++ b/src/Data/Document/Document.php
@@ -2,28 +2,37 @@
 
 namespace Torr\PrismicApi\Data\Document;
 
+use Symfony\Component\Validator\Constraints as Assert;
 use Torr\PrismicApi\Data\Dataset;
-use Torr\PrismicApi\Exception\Data\InvalidDataStructureException;
+use Torr\PrismicApi\Data\DataStructureValidationTrait;
 
 /**
- * A top level
+ * A top level base class for representing documents
  */
 abstract class Document extends Dataset
 {
+	use DataStructureValidationTrait;
 	protected DocumentAttributes $attributes;
 
 	/**
 	 */
 	public function __construct (array $data)
 	{
-		$itemData = $data["data"] ?? null;
+		$this->validateDataStructure(
+			$data,
+			new Assert\Collection([
+				"fields" => [
+					"data" => [
+						new Assert\NotNull(),
+						new Assert\Type("array"),
+					],
+				],
+				"allowExtraFields" => true,
+				"allowMissingFields" => false,
+			]),
+		);
 
-		if (!\is_array($itemData))
-		{
-			throw new InvalidDataStructureException(static::class, null, "No nested data key.");
-		}
-
-		parent::__construct($itemData);
+		parent::__construct($data["data"]);
 		$this->attributes = new DocumentAttributes($data);
 	}
 

--- a/src/Data/Document/DocumentAttributes.php
+++ b/src/Data/Document/DocumentAttributes.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+namespace Torr\PrismicApi\Data\Document;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+use Torr\PrismicApi\Data\Dataset;
+
+final class DocumentAttributes extends Dataset
+{
+	private \DateTimeImmutable $firstPublicationDate;
+	private \DateTimeImmutable $lastPublicationDate;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct (array $data)
+	{
+		parent::__construct($data);
+
+		$this->firstPublicationDate = $this->parseDate($data["first_publication_date"]);
+		$this->lastPublicationDate = $this->parseDate($data["last_publication_date"]);
+	}
+
+
+	/**
+	 * Returns the ID of the document
+	 */
+	public function getId () : string
+	{
+		return $this->data["id"];
+	}
+
+
+	/**
+	 * Returns the UID of the document.
+	 * If set, it is guaranteed to be unique for this locale + document type.
+	 */
+	public function getUid () : ?string
+	{
+		return $this->data["uid"];
+	}
+
+
+	/**
+	 * Returns the document type
+	 */
+	public function getType () : string
+	{
+		return $this->data["type"];
+	}
+
+
+	/**
+	 * Returns the language code of this document
+	 */
+	public function getLanguage () : string
+	{
+		return $this->data["lang"];
+	}
+
+
+	/**
+	 * Returns the internal document's tags.
+	 *
+	 * @return string[]
+	 */
+	public function getTags () : array
+	{
+		return $this->data["tags"];
+	}
+
+
+	/**
+	 */
+	public function getFirstPublicationDate () : \DateTimeImmutable
+	{
+		return $this->firstPublicationDate;
+	}
+
+	/**
+	 */
+	public function getLastPublicationDate () : \DateTimeImmutable
+	{
+		return $this->lastPublicationDate;
+	}
+
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function getValidationConstraints () : ?Constraint
+	{
+		return new Assert\Collection([
+			"fields" => [
+				"id" => [
+					new Assert\NotNull(),
+					new Assert\Type("string"),
+				],
+				"uid" => [
+					new Assert\Type("string"),
+				],
+				"type" => [
+					new Assert\NotNull(),
+					new Assert\Type("string"),
+				],
+				"tags" => [
+					new Assert\NotNull(),
+					new Assert\Type("array"),
+					new Assert\All([
+						"constraints" => [
+							new Assert\NotNull(),
+							new Assert\Type("string"),
+						],
+					]),
+				],
+				"first_publication_date" => [
+					new Assert\NotNull(),
+					new Assert\Type("string"),
+					new Assert\DateTime(\DateTimeInterface::RFC3339),
+				],
+				"last_publication_date" => [
+					new Assert\NotNull(),
+					new Assert\Type("string"),
+					new Assert\DateTime(\DateTimeInterface::RFC3339),
+				],
+				"lang" => [
+					new Assert\NotNull(),
+					new Assert\Type("string"),
+				],
+			],
+			"allowMissingFields" => false,
+			"allowExtraFields" => true,
+		]);
+	}
+
+
+	/**
+	 * Parses the given date
+	 */
+	private function parseDate (string $date) : \DateTimeImmutable
+	{
+		$parsed = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339, $date);
+		\assert($parsed instanceof \DateTimeImmutable);
+		return $parsed;
+	}
+}

--- a/src/Exception/Data/InvalidDataStructureException.php
+++ b/src/Exception/Data/InvalidDataStructureException.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Torr\PrismicApi\Exception\Data;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Torr\PrismicApi\Exception\PrismicApiException;
+
+final class InvalidDataStructureException extends \InvalidArgumentException implements PrismicApiException
+{
+	private ?ConstraintViolationListInterface $violations;
+
+	/**
+	 */
+	public function __construct (
+		string $type,
+		?ConstraintViolationListInterface $violations = null,
+		?string $message = null,
+		?\Throwable $previous = null,
+	)
+	{
+		parent::__construct(
+			\sprintf(
+				"Failed to validate type '%s'%s%s",
+				$type,
+				null !== $message
+					? " ({$message})"
+					: "",
+				$violations instanceof \Stringable
+					? ": {$violations}"
+					: "",
+			),
+			0,
+			$previous,
+		);
+
+		$this->violations = $violations;
+	}
+
+	/**
+	 */
+	public function getViolations () : ?ConstraintViolationListInterface
+	{
+		return $this->violations;
+	}
+}

--- a/tests/Data/DatasetTest.php
+++ b/tests/Data/DatasetTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Torr\PrismicApi\Data;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+use Torr\PrismicApi\Data\Dataset;
+use Torr\PrismicApi\Exception\Data\InvalidDataStructureException;
+
+final class DatasetTest extends TestCase
+{
+	/**
+	 */
+	public function provideConstruction () : iterable
+	{
+		yield "no constraint" => [["some" => "data"], null, true];
+
+		yield "basic valid" => [
+			["some" => "data"],
+			new Assert\Collection([
+				"fields" => [
+					"some" => [
+						new Assert\NotNull(),
+						new Assert\Type("string"),
+					],
+				],
+			]),
+			true,
+		];
+
+		yield "basic invalid" => [
+			["some" => null],
+			new Assert\Collection([
+				"fields" => [
+					"some" => [
+						new Assert\NotNull(),
+						new Assert\Type("string"),
+					],
+				],
+			]),
+			false,
+		];
+	}
+
+
+	/**
+	 * @dataProvider provideConstruction
+	 */
+	public function testConstruction (array $data, ?Constraint $constraint, bool $shouldBeValid) : void
+	{
+		if (!$shouldBeValid)
+		{
+			$this->expectException(InvalidDataStructureException::class);
+		}
+
+		// construct and let possibly throw
+		$this->createDataset($data, $constraint);
+
+		if ($shouldBeValid)
+		{
+			$this->assertTrue(true);
+		}
+	}
+
+
+	/**
+	 */
+	private function createDataset (array $data, ?Constraint $constraint) : Dataset
+	{
+		return new class ($data, $constraint) extends Dataset
+		{
+			public function __construct (array $data, private ?Constraint $constraint)
+			{
+				parent::__construct($data);
+			}
+
+			protected function getValidationConstraints () : ?Constraint
+			{
+				return $this->constraint;
+			}
+		};
+	}
+}

--- a/tests/Data/Document/DocumentTest.php
+++ b/tests/Data/Document/DocumentTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Torr\PrismicApi\Data\Document;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints as Assert;
+use Torr\PrismicApi\Data\Document\Document;
+use Torr\PrismicApi\Exception\Data\InvalidDataStructureException;
+
+final class DocumentTest extends TestCase
+{
+	/**
+	 */
+	public function provideData () : iterable
+	{
+		$baseData = [
+			"id" => "123",
+			"uid" => null,
+			"type" => "test",
+			"tags" => [],
+			"first_publication_date" => "2021-01-01T01:01:01+00:00",
+			"last_publication_date" => "2021-01-01T01:01:01+00:00",
+			"lang" => "de",
+			"data" => [],
+		];
+
+		yield "minimal valid base date" => [
+			$baseData,
+			null,
+			true,
+		];
+
+		yield "maximum valid base date" => [
+			\array_replace($baseData, [
+				"uid" => "test",
+			]),
+			null,
+			true,
+		];
+
+
+		yield "no data at all" => [
+			[],
+			null,
+			false,
+		];
+
+		// check for missing key
+		foreach ($baseData as $key => $value)
+		{
+			$newData = $baseData;
+			unset($newData[$key]);
+
+			yield "missing key: {$key}" => [
+				$newData,
+				null,
+				false,
+			];
+		}
+
+
+		yield "custom data invalid" => [
+			$baseData,
+			new Assert\Collection([
+				"fields" => [
+					"test" => [
+						new Assert\NotNull(),
+					],
+				],
+			]),
+			false,
+		];
+
+		yield "custom data valid" => [
+			\array_replace($baseData, [
+				"data" => [
+					"test" => 1,
+				],
+			]),
+			new Assert\Collection([
+				"fields" => [
+					"test" => [
+						new Assert\NotNull(),
+					],
+				],
+			]),
+			true,
+		];
+
+		yield "data invalid type" => [
+			\array_replace($baseData, [
+				"data" => 1,
+			]),
+			null,
+			false,
+		];
+	}
+
+
+	/**
+	 * @dataProvider provideData
+	 */
+	public function testConstruction (array $data, ?Constraint $constraint, bool $shouldBeValid) : void
+	{
+		if (!$shouldBeValid)
+		{
+			$this->expectException(InvalidDataStructureException::class);
+		}
+
+		// construct and let possibly throw
+		$this->createDocument($data, $constraint);
+
+		if ($shouldBeValid)
+		{
+			$this->assertTrue(true);
+		}
+	}
+
+
+	/**
+	 */
+	private function createDocument (array $data, ?Constraint $constraint) : Document
+	{
+		return new class ($data, $constraint) extends Document
+		{
+			public function __construct (array $data, private ?Constraint $constraint)
+			{
+				parent::__construct($data);
+			}
+
+			protected function getValidationConstraints () : ?Constraint
+			{
+				return $this->constraint;
+			}
+		};
+	}
+}


### PR DESCRIPTION
So, the gist of the changes is that we remove all runtime checks and just use validation.

This PR adds several basic things

* a base `Dataset`, which is just the most low level component. It receives data and you need to define the validation constraints, and it just validates the data against your constraints.
* a bit higher, there is `Document`, which extracts your custom data from the basic document attributes (see below). You only define the validation constraints for your custom fields and it does all the work for you.
* a `DocumentAttributes` wrapper, that validates the basic attributes of a document as given by prismic.

`Dataset` is a standalone type, so that you can extract subtypes (like subentries in a block or sth like that) easily and keep reusing the same basic validation structure.

ToDos for the follow up PRs:

* Add a integration for slices + slice attributes (?) + slice type handlers + a factory
* Environment should just use `Dataset` and be probably be renamed (as it's only internal).